### PR TITLE
优化抖音get的传参方式

### DIFF
--- a/service/douyin/logic/common.py
+++ b/service/douyin/logic/common.py
@@ -4,6 +4,7 @@ from lib import requests
 import urllib.parse
 import re
 import random
+from urllib.parse import urlencode
 
 HOST = 'https://www.douyin.com'
 
@@ -132,19 +133,21 @@ async def common_request(uri: str, params: dict, headers: dict) -> tuple[dict, b
     a_bogus = DOUYIN_SIGN.call(call_name, query, headers["User-Agent"])
     params["a_bogus"] = a_bogus
 
+    full_url = f"{url}?{urlencode(params)}"
+
     logger.info(
-        f'url: {url}, request {url}, params={params}, headers={headers}')
-    response = await requests.get(url, params=params, headers=headers)
+        f'url: {full_url}, params: {params}, headers={headers}')
+    response = await requests.get(full_url, params=None, headers=headers)
     logger.info(
-        f'url: {url}, params: {params}, response, code: {response.status_code}, body: {response.text}')
+        f'url: {full_url}, params: {params}, response, code: {response.status_code}, body: {response.text}')
 
     if response.status_code != 200 or response.text == '':
         logger.error(
-            f'url: {url}, params: {params}, request error, code: {response.status_code}, body: {response.text}')
+            f'url: {full_url}, params: {params}, request error, code: {response.status_code}, body: {response.text}')
         return {}, False
     if response.json().get('status_code', 0) != 0:
         logger.error(
-            f'url: {url}, params: {params}, request error, code: {response.status_code}, body: {response.text}')
+            f'url: {full_url}, params: {params}, request error, code: {response.status_code}, body: {response.text}')
         return response.json(), False
 
     return response.json(), True


### PR DESCRIPTION
今天试了下"用户信息及作品获取"这个接口，发现响应结果返回的“user”和“aweme_list”结果异常，一会user字段没值，一会aweme_list字段没值，所以我小改了下 http get 的传参方式，目前响应结果都是正常的。

```sh
# 用户信息及作品获取
http://127.0.0.1:8080/douyin/user?id=MS4wLjABAAAAr1-Mpm0j_ViyOHeN6iYTuAy7umGPVA4VU0f62pxTOjbFmMy8FOdj2-_upE2sTd9c&offset=0&limit=10
```